### PR TITLE
Fix build paths for root deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ br-english/
 
 ## Como Executar Localmente
 
-1. **Instalar dependências:**
+1. **Instalar dependências (requer [pnpm](https://pnpm.io))**:
    ```bash
-   npm install
+   pnpm install
    ```
 
 2. **Executar em modo de desenvolvimento:**
    ```bash
-   npm run dev
+   pnpm run dev
    ```
 
 3. **Criar build de produção:**
    ```bash
-   npm run build
+   pnpm run build
    ```
 
 ## Publicação no GitHub Pages

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,10 +5,11 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(),tailwindcss()],
+  base: './',
+  plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "./src"),
+      '@': path.resolve('src'),
     },
   },
 })


### PR DESCRIPTION
## Summary
- ensure Vite builds use relative paths for deployment at site root
- update README instructions for pnpm

## Testing
- `pnpm install`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6848d3fe670c8323b01fa3078df35a3e